### PR TITLE
Use ThreadLocal for FtpResponseEncoder.ENCODER.

### DIFF
--- a/core/src/main/java/org/apache/ftpserver/listener/nio/FtpResponseEncoder.java
+++ b/core/src/main/java/org/apache/ftpserver/listener/nio/FtpResponseEncoder.java
@@ -37,8 +37,12 @@ import org.apache.mina.filter.codec.demux.MessageEncoder;
  * @author <a href="http://mina.apache.org">Apache MINA Project</a>
  */
 public class FtpResponseEncoder extends ProtocolEncoderAdapter {
-    private static final CharsetEncoder ENCODER = Charset.forName("UTF-8")
-            .newEncoder();
+    private static final ThreadLocal<CharsetEncoder> ENCODER = new ThreadLocal<CharsetEncoder>() {
+        @Override
+        protected CharsetEncoder initialValue() {
+            return Charset.forName("UTF-8").newEncoder();
+        }
+    };
 
     public void encode(IoSession session, Object message,
             ProtocolEncoderOutput out) throws Exception {
@@ -46,7 +50,7 @@ public class FtpResponseEncoder extends ProtocolEncoderAdapter {
 
         IoBuffer buf = IoBuffer.allocate(value.length()).setAutoExpand(true);
 
-        buf.putString(value, ENCODER);
+        buf.putString(value, ENCODER.get());
 
         buf.flip();
         out.write(buf);


### PR DESCRIPTION
CharsetEncoder isn't thread safe so the original code often crashes
when there are multiple responses being encoded concurrently. We can
use a ThreadLocal for the CharsetEncoder to fix this.