### PR TITLE
[FTPSERVER-506] Binary compatibility is broken in ftpserver-core 1.1.3,

### DIFF
--- a/core/src/main/java/org/apache/ftpserver/ssl/SslConfiguration.java
+++ b/core/src/main/java/org/apache/ftpserver/ssl/SslConfiguration.java
@@ -82,7 +82,9 @@ public interface SslConfiguration {
      * 
      * @return The list of enabled protocols as a String
      */
-    String[] getEnabledProtocols();
+     default String[] getEnabledProtocols() {
+    	 return new String[] { getEnabledProtocol() };
+     }
 
     /**
      * Return the required client authentication setting


### PR DESCRIPTION
1.2.0 vs 1.1.2