### PR TITLE
Verify passiveAddress and passiveExternalAddress in DataConnectionConfigurationFactory only if needed

### DIFF
--- a/core/src/main/java/org/apache/ftpserver/DataConnectionConfigurationFactory.java
+++ b/core/src/main/java/org/apache/ftpserver/DataConnectionConfigurationFactory.java
@@ -73,8 +73,12 @@ public class DataConnectionConfigurationFactory {
      */
     private void checkValidAddresses(){
         try{
-            InetAddress.getByName(passiveAddress);
-            InetAddress.getByName(passiveExternalAddress);
+            if(passiveAddress!=null) {
+                InetAddress.getByName(passiveAddress);
+            }
+            if(passiveExternalAddress!=null) {
+                InetAddress.getByName(passiveExternalAddress);
+            }
         }catch(UnknownHostException ex){
             throw new FtpServerConfigurationException("Unknown host", ex);
         }


### PR DESCRIPTION
Reported as https://github.com/apache/mina-ftpserver/issues/30