### PR TITLE
inmemory file system implementation

### DIFF
--- a/core/src/main/java/org/apache/ftpserver/filesystem/inmemoryfs/InMemoryFileSystemFactory.java
+++ b/core/src/main/java/org/apache/ftpserver/filesystem/inmemoryfs/InMemoryFileSystemFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ftpserver.filesystem.inmemoryfs;
+
+import org.apache.ftpserver.filesystem.inmemoryfs.impl.InMemoryFileSystemView;
+import org.apache.ftpserver.ftplet.FileSystemFactory;
+import org.apache.ftpserver.ftplet.FileSystemView;
+import org.apache.ftpserver.ftplet.FtpException;
+import org.apache.ftpserver.ftplet.User;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryFileSystemFactory implements FileSystemFactory {
+
+    private final static Map<String, InMemoryFileSystemView> filesystemMap = new ConcurrentHashMap<>();
+
+    @Override
+    public synchronized FileSystemView createFileSystemView(User user) throws FtpException {
+        Objects.requireNonNull(user);
+
+        if (filesystemMap.containsKey(user.getName())) {
+            return filesystemMap.get(user.getName());
+        }
+        InMemoryFileSystemView view = new InMemoryFileSystemView(user);
+        filesystemMap.put(user.getName(), view);
+        return view;
+    }
+
+
+}

--- a/core/src/main/java/org/apache/ftpserver/filesystem/inmemoryfs/impl/InMemoryFileSystemView.java
+++ b/core/src/main/java/org/apache/ftpserver/filesystem/inmemoryfs/impl/InMemoryFileSystemView.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ftpserver.filesystem.inmemoryfs.impl;
+
+import org.apache.ftpserver.ftplet.FileSystemView;
+import org.apache.ftpserver.ftplet.FtpFile;
+import org.apache.ftpserver.ftplet.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InMemoryFileSystemView implements FileSystemView {
+
+    public static final String PARENT_DIRECTORY = "..";
+    public static final String CURRENT_DIRECTORY = ".";
+    public static final String CURRENT = "./";
+    private static final Logger log = LoggerFactory.getLogger(InMemoryFileSystemView.class);
+    private final InMemoryFtpFile homeDirectory;
+    private InMemoryFtpFile workingDirectory;
+
+    public InMemoryFileSystemView(User user) {
+        validateUser(user);
+        this.homeDirectory = InMemoryFtpFile.createRoot(user.getHomeDirectory());
+        this.workingDirectory = homeDirectory;
+    }
+
+    private void validateUser(User user) {
+        if (user == null) {
+            throw new IllegalArgumentException("user cannot be null");
+        }
+        if (user.getHomeDirectory() == null) {
+            throw new IllegalArgumentException("User home directory cannot be null");
+        }
+    }
+
+    @Override
+    public FtpFile getHomeDirectory() {
+        return homeDirectory;
+    }
+
+    @Override
+    public FtpFile getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    @Override
+    public boolean changeWorkingDirectory(String path) {
+        log.debug("changing working directory from {} to path {}", workingDirectory.getAbsolutePath(), path);
+        if (isPathNotMatchingCurrentWorkingDirPath(path)) {
+            InMemoryFtpFile mayBeWorkingDirectory;
+            if (isAbsolute(path)) {
+                mayBeWorkingDirectory = homeDirectory.find(path);
+            } else {
+                mayBeWorkingDirectory = workingDirectory.find(path);
+            }
+
+            if (mayBeWorkingDirectory.doesExist() && mayBeWorkingDirectory.isDirectory()) {
+                workingDirectory = mayBeWorkingDirectory;
+                log.debug("changed working directory to {}", workingDirectory.getAbsolutePath());
+                return true;
+            }
+            log.info("changing working directory failed - cannot find file by path {}", path);
+            return false;
+        }
+        //path is same as current working directory
+        return true;
+    }
+
+    private boolean isPathNotMatchingCurrentWorkingDirPath(String dir) {
+        return !workingDirectory.getAbsolutePath().equals(dir);
+    }
+
+    private FtpFile getFile(String path, InMemoryFtpFile file) {
+        path = removeSlash(path);
+
+        if (path.startsWith(PARENT_DIRECTORY)) {
+            if (path.equals(PARENT_DIRECTORY)) {
+                return file.getParent();
+            } else {
+                if (file.getParent() == null) {
+                    return null;
+                }
+                return getFile(path.substring(2), (InMemoryFtpFile) file.getParent());
+            }
+        } else if (path.startsWith(CURRENT_DIRECTORY)) {
+            if (path.equals(CURRENT_DIRECTORY)) {
+                return file;
+            } else if (path.startsWith(CURRENT)) {
+                if (path.equals(CURRENT)) {
+                    return file;
+                } else {
+                    return getFile(path.substring(2), file);
+                }
+            }
+        }
+
+        return file.find(path);
+    }
+
+    @Override
+    public FtpFile getFile(String path) {
+        if (isAbsolute(path)) {
+            return getFile(path, homeDirectory);
+        } else {
+            return getFile(path, workingDirectory);
+        }
+    }
+
+    private boolean isAbsolute(String path) {
+        return path.startsWith("/");
+    }
+
+    private String removeSlash(String path) {
+        if (path.startsWith("/")) {
+            return path.substring(1);
+        }
+        return path;
+    }
+
+    @Override
+    public boolean isRandomAccessible() {
+        return false;
+    }
+
+    @Override
+    public void dispose() {
+    }
+}

--- a/core/src/main/java/org/apache/ftpserver/filesystem/inmemoryfs/impl/InMemoryFtpFile.java
+++ b/core/src/main/java/org/apache/ftpserver/filesystem/inmemoryfs/impl/InMemoryFtpFile.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ftpserver.filesystem.inmemoryfs.impl;
+
+import org.apache.ftpserver.ftplet.FtpFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class InMemoryFtpFile implements FtpFile {
+
+    public static final String SLASH = "/";
+    private static final Logger log = LoggerFactory.getLogger(InMemoryFtpFile.class);
+    private boolean isExist = false;
+    private boolean isFolder = true;
+    private String name;
+    private Map<String, InMemoryFtpFile> children;
+    private InMemoryFtpFile parent;
+    private long lastModify = System.currentTimeMillis();
+
+    private ByteArrayOutputStream data = new ByteArrayOutputStream();
+
+    private InMemoryFtpFile(String name, InMemoryFtpFile parent) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("null or empty file name");
+        }
+
+        this.name = name;
+        this.children = new ConcurrentHashMap<>();
+        this.parent = parent;
+        log.debug("created file in path {}", this.getAbsolutePath());
+    }
+
+    static InMemoryFtpFile createRoot(String name) {
+        InMemoryFtpFile file = new InMemoryFtpFile(name, null);
+        file.isExist = true;
+        file.isFolder = true;
+        return file;
+    }
+
+    private static InMemoryFtpFile createLeaf(String name, InMemoryFtpFile parent) {
+        Objects.requireNonNull(parent);
+        return new InMemoryFtpFile(name, parent);
+    }
+
+    @Override
+    public String getAbsolutePath() {
+        if (isRoot()) {
+            return name;
+        }
+        return parent.getAbsolutePath(name);
+    }
+
+    private String getAbsolutePath(String childPath) {
+        if (isRoot()) {
+            return getName() + childPath;
+        }
+        return parent.getAbsolutePath(name + SLASH + childPath);
+    }
+
+    private boolean isRoot() {
+        return parent == null;
+    }
+
+    protected List<InMemoryFtpFile> getChildren() {
+        return children.values().stream().filter(InMemoryFtpFile::doesExist).collect(Collectors.toList());
+    }
+
+    public InMemoryFtpFile find(String path) {
+        if (path.startsWith(SLASH)) {
+            path = path.substring(1);
+        }
+
+        if (path.isEmpty()) {
+            return this;
+        }
+
+        if (isGoUpPath(path)) {
+            if (isRoot()) {
+                return this;
+            }
+            return parent.find(path.substring(2));
+        }
+
+        String[] splitPath = path.split(SLASH, 2);
+
+        if (isMultiFolderPath(splitPath)) {
+            InMemoryFtpFile file = this.find(splitPath[0]);
+            return file.find(splitPath[1]);
+        } else {
+            InMemoryFtpFile leaf = InMemoryFtpFile.createLeaf(path, this);
+            InMemoryFtpFile existingFile = children.putIfAbsent(leaf.getName(), leaf);
+            return existingFile == null ? leaf : existingFile;
+        }
+    }
+
+    private boolean isMultiFolderPath(String[] splitPath) {
+        return splitPath.length > 1;
+    }
+
+    private boolean isGoUpPath(String path) {
+        return path.startsWith("..");
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean isHidden() {
+        return false;
+    }
+
+    @Override
+    public boolean isDirectory() {
+        return isRoot() || isFolder;
+    }
+
+    @Override
+    public boolean isFile() {
+        return !isRoot() && !isFolder;
+    }
+
+    @Override
+    public boolean doesExist() {
+        return isExist;
+    }
+
+    @Override
+    public boolean isReadable() {
+        return true;
+    }
+
+    @Override
+    public boolean isWritable() {
+        return true;
+    }
+
+    @Override
+    public boolean isRemovable() {
+        return true;
+    }
+
+    @Override
+    public String getOwnerName() {
+        return null;
+    }
+
+    @Override
+    public String getGroupName() {
+        return null;
+    }
+
+    @Override
+    public int getLinkCount() {
+        return 0;
+    }
+
+    @Override
+    public long getLastModified() {
+        return lastModify;
+    }
+
+    @Override
+    public boolean setLastModified(long time) {
+        lastModify = time;
+        return true;
+    }
+
+    @Override
+    public long getSize() {
+        return data.size();
+    }
+
+    @Override
+    public Object getPhysicalFile() {
+        throw new UnsupportedOperationException("physical file not available in memory file system");
+    }
+
+    @Override
+    public boolean mkdir() {
+        log.debug("creating folder at path {}", getAbsolutePath());
+        if (isExist && isFolder) {
+            return false;
+        }
+        if (!isRoot()) {
+            isExist = true;
+            isFolder = true;
+            parent.mkdir();
+        }
+        return true;
+    }
+
+    @Override
+    public boolean delete() {
+        log.debug("deleting file at path {}", getAbsolutePath());
+        isExist = false;
+        this.children = null;
+        removeFromParent();
+        this.parent = null;
+        return true;
+    }
+
+    private void removeFromParent() {
+        parent.children.remove(getName());
+    }
+
+    @Override
+    public boolean move(FtpFile destination) {
+        log.debug("moving file from {} to {}", getAbsolutePath(), destination.getAbsolutePath());
+        removeFromParent();
+        InMemoryFtpFile inMemoryDestination = (InMemoryFtpFile) destination;
+        clone(inMemoryDestination);
+        inMemoryDestination.parent.getChildren().add(inMemoryDestination);
+        return true;
+    }
+
+    private void clone(InMemoryFtpFile target) {
+        target.data = this.data;
+        target.isFolder = this.isFolder;
+        target.children = this.children;
+        target.isExist = this.isExist;
+        target.parent = this.parent;
+        target.name = this.name;
+    }
+
+    @Override
+    public List<? extends FtpFile> listFiles() {
+        if (isDirectory()) {
+            return children.values().stream().filter(InMemoryFtpFile::doesExist).collect(Collectors.toList());
+        }
+
+        return null;
+    }
+
+    @Override
+    public OutputStream createOutputStream(long offset) {
+        isFolder = false;
+        isExist = true;
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be equal 0");
+        }
+        return new ByteArrayOutputStreamWrapper(data);
+    }
+
+    @Override
+    public InputStream createInputStream(long offset) throws IOException {
+        validateInputStream(offset);
+        return new ByteArrayInputStream(data.toByteArray());
+    }
+
+    private void validateInputStream(long offset) throws IOException {
+        if (isFolder) {
+            throw new IOException("cannot read bytes from folder");
+        }
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be equal 0");
+        }
+    }
+
+    public FtpFile getParent() {
+        return parent;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InMemoryFtpFile file = (InMemoryFtpFile) o;
+        return Objects.equals(getAbsolutePath(), file.getAbsolutePath());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getAbsolutePath());
+    }
+
+    private static class ByteArrayOutputStreamWrapper extends OutputStream {
+
+        private final ByteArrayOutputStream byteArrayOutputStream;
+
+        ByteArrayOutputStreamWrapper(ByteArrayOutputStream byteArrayOutputStream) {
+            this.byteArrayOutputStream = byteArrayOutputStream;
+        }
+
+        @Override
+        public void write(int b) {
+            byteArrayOutputStream.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            byteArrayOutputStream.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            byteArrayOutputStream.write(b, off, len);
+        }
+    }
+}

--- a/core/src/test/java/org/apache/ftpserver/filesystem/inmemory/impl/InMemoryFileSystemViewTest.java
+++ b/core/src/test/java/org/apache/ftpserver/filesystem/inmemory/impl/InMemoryFileSystemViewTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ftpserver.filesystem.inmemory.impl;
+
+import junit.framework.TestCase;
+import org.apache.ftpserver.filesystem.inmemoryfs.impl.InMemoryFileSystemView;
+import org.apache.ftpserver.usermanager.impl.BaseUser;
+
+public class InMemoryFileSystemViewTest extends TestCase {
+
+    private final String HOME_DIR = "/";
+    protected BaseUser user = new BaseUser();
+
+    public void testShouldNotCreateViewIfUserIsNull() {
+        try {
+            new InMemoryFileSystemView(null);
+            fail("user should not be null");
+        } catch (Exception ex) {
+            assertTrue(ex instanceof IllegalArgumentException);
+        }
+    }
+
+    public void testShouldNotCreateViewIfUserIsHasNoHomeDir() {
+        try {
+            user.setHomeDirectory(null);
+            new InMemoryFileSystemView(user);
+            fail("user home directory should not be ull");
+        } catch (Exception ex) {
+            assertTrue(ex instanceof IllegalArgumentException);
+        }
+    }
+
+    public void testHomeDir() throws Exception {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        assertEquals(HOME_DIR, view.getHomeDirectory().getAbsolutePath());
+    }
+
+    public void testWorkingDir() throws Exception {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        assertEquals(HOME_DIR, view.getWorkingDirectory().getAbsolutePath());
+    }
+
+    public void testChangeWorkingDir() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        view.getFile("1").mkdir();
+
+        view.changeWorkingDirectory("1");
+
+        assertEquals("1", view.getWorkingDirectory().getName());
+    }
+
+    public void testChangeWorkingDirToGoUp() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        view.getFile("1").mkdir();
+
+        view.changeWorkingDirectory("1");
+
+        assertEquals("1", view.getWorkingDirectory().getName());
+
+        view.changeWorkingDirectory("..");
+        assertEquals("/", view.getWorkingDirectory().getAbsolutePath());
+    }
+
+    public void testChangeWorkingDirToGoUp2Times() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        view.getFile("1/2").mkdir();
+
+        view.changeWorkingDirectory("1/2");
+
+        assertEquals("2", view.getWorkingDirectory().getName());
+
+        assertEquals("/", view.getFile("../..").getAbsolutePath());
+    }
+
+    public void testGetCurrentDir() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        assertEquals("/", view.getFile(".").getAbsolutePath());
+    }
+
+    private InMemoryFileSystemView getInMemoryFileSystemView() {
+        user.setHomeDirectory(HOME_DIR);
+        InMemoryFileSystemView view = new InMemoryFileSystemView(user);
+        return view;
+    }
+
+
+}

--- a/core/src/test/java/org/apache/ftpserver/filesystem/inmemory/impl/InMemoryFtpFileTest.java
+++ b/core/src/test/java/org/apache/ftpserver/filesystem/inmemory/impl/InMemoryFtpFileTest.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ftpserver.filesystem.inmemory.impl;
+
+import junit.framework.TestCase;
+import org.apache.ftpserver.filesystem.inmemoryfs.impl.InMemoryFileSystemView;
+import org.apache.ftpserver.filesystem.inmemoryfs.impl.InMemoryFtpFile;
+import org.apache.ftpserver.ftplet.FtpFile;
+import org.apache.ftpserver.usermanager.impl.BaseUser;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+public class InMemoryFtpFileTest extends TestCase {
+
+    public static final String FILE1_NAME = "1";
+    public static final String FILE2_NAME = "2";
+    public static final String FILE3_NAME = "3";
+    protected BaseUser user = new BaseUser();
+    private final static String HOME_DIR = "/";
+
+    public void testGetAbsolutePath() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file1 = view.getFile(FILE1_NAME);
+        FtpFile file2 = view.getFile(FILE1_NAME + "/" + FILE2_NAME);
+        assertEquals(HOME_DIR + FILE1_NAME, file1.getAbsolutePath());
+        assertEquals(HOME_DIR + FILE1_NAME + "/" + FILE2_NAME, file2.getAbsolutePath());
+    }
+
+    public void testFindFile() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+
+        InMemoryFtpFile file = (InMemoryFtpFile) view.getFile(FILE1_NAME);
+        file.mkdir();
+
+        InMemoryFtpFile subFile1 = (InMemoryFtpFile) view.getFile(file.getAbsolutePath() + "/" + FILE2_NAME);
+        subFile1.mkdir();
+
+        assertEquals(file, file.find(""));
+        assertEquals(subFile1, file.find(subFile1.getName()));
+    }
+
+    public void testGetName() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file = view.getFile(FILE1_NAME);
+
+        assertEquals(FILE1_NAME, file.getName());
+    }
+
+    public void testIsDirectory() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file = view.getFile(FILE1_NAME);
+
+        assertTrue(file.isDirectory());
+        assertFalse(file.isFile());
+    }
+
+    public void testIsFile() throws Exception{
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file = view.getFile(FILE1_NAME);
+        file.createOutputStream(0).close(); //setting that file is file, not directory
+        assertFalse(file.isDirectory());
+        assertTrue(file.isFile());
+    }
+    public void testModificationTime() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file1 = view.getFile(FILE1_NAME);
+
+        long time = System.currentTimeMillis();
+
+        file1.setLastModified(time);
+
+        assertEquals(time, file1.getLastModified());
+    }
+
+    public void testGetSize() throws Exception {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file = view.getFile(FILE1_NAME);
+
+        OutputStream outputStream = file.createOutputStream(0);
+        String data = "Test";
+        outputStream.write(data.getBytes());
+        outputStream.close();
+
+        assertEquals(data.getBytes().length, file.getSize());
+    }
+
+    public void testDeleteLeaf() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file1 = view.getFile(FILE1_NAME);
+        view.changeWorkingDirectory(FILE1_NAME);
+        FtpFile file2 = view.getFile(FILE1_NAME + "/" + FILE2_NAME);
+        file2.mkdir();
+
+        assertTrue(file2.delete());
+
+        assertEquals(1, view.getHomeDirectory().listFiles().size());
+        assertEquals(0, file1.listFiles().size());
+    }
+
+    public void testDeleteRoot() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file1 = view.getFile(FILE1_NAME);
+        file1.mkdir();
+        view.changeWorkingDirectory(FILE1_NAME);
+
+        assertTrue(file1.delete());
+
+        assertEquals(0, view.getHomeDirectory().listFiles().size());
+    }
+
+    public void testWriteAndRead() throws Exception {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file = view.getFile(FILE1_NAME);
+
+        OutputStream outputStream = file.createOutputStream(0);
+        String input_data = "Hello, World!";
+        outputStream.write(input_data.getBytes());
+        outputStream.close();
+
+        InputStream inputStream = file.createInputStream(0);
+        StringBuilder output_data = new StringBuilder();
+        int data;
+        while ((data = inputStream.read()) != -1) {
+            output_data.append((char) data);
+        }
+        inputStream.close();
+
+        assertEquals(input_data, output_data.toString());
+        assertEquals(1, view.getHomeDirectory().listFiles().size());
+
+    }
+
+    public void testMove() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file1 = view.getFile(FILE1_NAME);
+        FtpFile file2 = view.getFile(FILE2_NAME);
+
+        file1.move(file2);
+
+        assertEquals(file1.getAbsolutePath(), file2.getAbsolutePath());
+        assertEquals(file1.getName(), file2.getName());
+        assertEquals(file1.getSize(), file2.getSize());
+    }
+
+    public void testListFiles() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file1 = view.getFile(FILE1_NAME);
+        file1.mkdir();
+        FtpFile file2 = view.getFile(FILE1_NAME + "/" + FILE2_NAME);
+        file2.mkdir();
+
+        List<FtpFile> result = (List<FtpFile>) file1.listFiles();
+        assertEquals(1, result.size());
+        assertEquals(file2, result.get(0));
+    }
+
+    public void testDeleteWithFilesInside() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file1 = view.getFile(FILE1_NAME);
+        file1.mkdir();
+
+        FtpFile file2 = view.getFile(FILE1_NAME + "/" + FILE2_NAME);
+        file2.mkdir();
+
+        file1.delete();
+        assertEquals(0, view.getHomeDirectory().listFiles().size());
+    }
+
+    public void testMultipleWorkingDirectoryChange() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        FtpFile file1 = view.getFile(FILE1_NAME);
+        file1.mkdir();
+
+        assertEquals(1, view.getHomeDirectory().listFiles().size());
+
+        FtpFile file2 = view.getFile(FILE1_NAME + "/" + FILE2_NAME);
+        file2.mkdir();
+
+        assertEquals(1, view.getHomeDirectory().listFiles().size());
+
+        view.changeWorkingDirectory(FILE1_NAME);
+
+        assertEquals(1, view.getHomeDirectory().listFiles().size());
+
+        view.changeWorkingDirectory(FILE2_NAME);
+
+        assertEquals(1, view.getHomeDirectory().listFiles().size());
+
+        view.changeWorkingDirectory("..");
+
+        assertEquals(1, view.getHomeDirectory().listFiles().size());
+
+        view.changeWorkingDirectory("..");
+
+        assertEquals(1, view.getHomeDirectory().listFiles().size());
+
+        assertEquals(1, view.getHomeDirectory().listFiles().size());
+        assertEquals(1, file1.listFiles().size());
+        assertEquals(0, file2.listFiles().size());
+    }
+
+    public void testCreateDirectoryByMultiDirectoryPath() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        view.getFile(FILE1_NAME + "/" + FILE2_NAME).mkdir();
+
+        assertEquals(1, view.getWorkingDirectory().listFiles().size());
+        assertTrue(view.getFile(FILE1_NAME).doesExist() && view.getFile(FILE1_NAME).isDirectory());
+
+        view.changeWorkingDirectory(FILE1_NAME);
+
+        assertEquals(1, view.getWorkingDirectory().listFiles().size());
+        assertTrue(view.getFile(FILE2_NAME).doesExist() && view.getFile(FILE2_NAME).isDirectory());
+
+        view.changeWorkingDirectory(FILE2_NAME);
+
+        assertEquals(0, view.getWorkingDirectory().listFiles().size());
+    }
+
+    public void testCWDToNotExisingDirectoryNotChangingIt() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        view.getFile(FILE1_NAME + "/" + FILE2_NAME + "/" + FILE3_NAME).mkdir();
+        view.changeWorkingDirectory(FILE1_NAME + "/" + FILE2_NAME + "/" + FILE3_NAME);
+
+        assertEquals(FILE3_NAME, view.getWorkingDirectory().getName());
+
+        view.changeWorkingDirectory("not_exist");
+
+        assertEquals(FILE3_NAME, view.getWorkingDirectory().getName());
+    }
+
+    public void testCreateDirectoryByMultiDirectoryAbsolutePath() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        view.getFile(HOME_DIR + "/" + FILE1_NAME + "/" + FILE2_NAME + "/" + FILE3_NAME).mkdir();
+
+        assertEquals(1, view.getHomeDirectory().listFiles().size()); // home
+        assertEquals(1, view.getHomeDirectory().listFiles().get(0).listFiles().size()); //1
+        assertEquals(1, view.getHomeDirectory().listFiles().get(0).listFiles().get(0).listFiles().size()); //2
+        assertEquals(0, view.getHomeDirectory().listFiles().get(0).listFiles().get(0).listFiles().get(0).listFiles().size()); //3
+    }
+
+    public void testGoUpDirectory() {
+        InMemoryFileSystemView view = getInMemoryFileSystemView();
+        view.getFile(HOME_DIR + "/" + FILE1_NAME + "/" + FILE2_NAME + "/" + FILE3_NAME).mkdir();
+
+        view.changeWorkingDirectory(HOME_DIR + "/" + FILE1_NAME + "/" + FILE2_NAME + "/" + FILE3_NAME);
+        view.changeWorkingDirectory("..");
+        assertEquals(FILE2_NAME, view.getWorkingDirectory().getName());
+    }
+
+    private InMemoryFileSystemView getInMemoryFileSystemView() {
+        user.setHomeDirectory(HOME_DIR);
+        return new InMemoryFileSystemView(user);
+    }
+
+}


### PR DESCRIPTION
in-memory file system implementation. why is this needed? In my case, for specific testing when I don't want to delete the created files after each run