### PR TITLE
Reduce GC Pressure by Storing Last Access Time as Primitive Long

### DIFF
--- a/core/src/main/java/org/apache/ftpserver/impl/FtpIoSession.java
+++ b/core/src/main/java/org/apache/ftpserver/impl/FtpIoSession.java
@@ -890,7 +890,7 @@ public class FtpIoSession implements IoSession {
      * @return The last access time
      */
     public Date getLastAccessTime() {
-        return (Date) getAttribute(ATTRIBUTE_LAST_ACCESS_TIME);
+        return new Date((Long) getAttribute(ATTRIBUTE_LAST_ACCESS_TIME));
     }
 
     /**
@@ -924,7 +924,7 @@ public class FtpIoSession implements IoSession {
      * Update the last-access-time session attribute with the current date
      */
     public void updateLastAccessTime() {
-        setAttribute(ATTRIBUTE_LAST_ACCESS_TIME, new Date());
+        setAttribute(ATTRIBUTE_LAST_ACCESS_TIME, System.currentTimeMillis());
     }
 
     /**

--- a/core/src/main/java/org/apache/ftpserver/impl/FtpIoSession.java
+++ b/core/src/main/java/org/apache/ftpserver/impl/FtpIoSession.java
@@ -36,6 +36,7 @@ import org.apache.ftpserver.ftplet.FtpSession;
 import org.apache.ftpserver.ftplet.Structure;
 import org.apache.ftpserver.ftplet.User;
 import org.apache.ftpserver.listener.Listener;
+import org.apache.ftpserver.util.LazyDateHolder;
 import org.apache.mina.core.filterchain.IoFilterChain;
 import org.apache.mina.core.future.CloseFuture;
 import org.apache.mina.core.future.ReadFuture;
@@ -57,60 +58,59 @@ import org.slf4j.LoggerFactory;
  * <strong>Internal class, do not use directly.</strong>
  *
  * @author <a href="http://mina.apache.org">Apache MINA Project</a>
- *
  */
 public class FtpIoSession implements IoSession {
     /// Contains user name between USER and PASS commands
-    /** Prefix for all the attributes*/
+    /** Prefix for all the attributes */
     public static final String ATTRIBUTE_PREFIX = "org.apache.ftpserver.";
 
     /** User argument attribute */
-    private static final String ATTRIBUTE_USER_ARGUMENT =           ATTRIBUTE_PREFIX + "user-argument";
+    private static final String ATTRIBUTE_USER_ARGUMENT = ATTRIBUTE_PREFIX + "user-argument";
 
     /** session ID attribute */
-    private static final String ATTRIBUTE_SESSION_ID =              ATTRIBUTE_PREFIX + "session-id";
+    private static final String ATTRIBUTE_SESSION_ID = ATTRIBUTE_PREFIX + "session-id";
 
     /** User attribute */
-    private static final String ATTRIBUTE_USER =                    ATTRIBUTE_PREFIX + "user";
+    private static final String ATTRIBUTE_USER = ATTRIBUTE_PREFIX + "user";
 
     /** Language attribute */
-    private static final String ATTRIBUTE_LANGUAGE =                ATTRIBUTE_PREFIX + "language";
+    private static final String ATTRIBUTE_LANGUAGE = ATTRIBUTE_PREFIX + "language";
 
     /** Login time attribute */
-    private static final String ATTRIBUTE_LOGIN_TIME =              ATTRIBUTE_PREFIX + "login-time";
+    private static final String ATTRIBUTE_LOGIN_TIME = ATTRIBUTE_PREFIX + "login-time";
 
     /** Data connection attribute */
-    private static final String ATTRIBUTE_DATA_CONNECTION =         ATTRIBUTE_PREFIX + "data-connection";
+    private static final String ATTRIBUTE_DATA_CONNECTION = ATTRIBUTE_PREFIX + "data-connection";
 
     /** File system attribute */
-    private static final String ATTRIBUTE_FILE_SYSTEM =             ATTRIBUTE_PREFIX + "file-system";
+    private static final String ATTRIBUTE_FILE_SYSTEM = ATTRIBUTE_PREFIX + "file-system";
 
     /** Rename from attribute */
-    private static final String ATTRIBUTE_RENAME_FROM =             ATTRIBUTE_PREFIX + "rename-from";
+    private static final String ATTRIBUTE_RENAME_FROM = ATTRIBUTE_PREFIX + "rename-from";
 
     /** File offset attribute */
-    private static final String ATTRIBUTE_FILE_OFFSET =             ATTRIBUTE_PREFIX + "file-offset";
+    private static final String ATTRIBUTE_FILE_OFFSET = ATTRIBUTE_PREFIX + "file-offset";
 
     /** Data type attribute */
-    private static final String ATTRIBUTE_DATA_TYPE =               ATTRIBUTE_PREFIX + "data-type";
+    private static final String ATTRIBUTE_DATA_TYPE = ATTRIBUTE_PREFIX + "data-type";
 
     /** Structure attribute */
-    private static final String ATTRIBUTE_STRUCTURE =               ATTRIBUTE_PREFIX + "structure";
+    private static final String ATTRIBUTE_STRUCTURE = ATTRIBUTE_PREFIX + "structure";
 
     /** Failed login attribute */
-    private static final String ATTRIBUTE_FAILED_LOGINS =           ATTRIBUTE_PREFIX + "failed-logins";
+    private static final String ATTRIBUTE_FAILED_LOGINS = ATTRIBUTE_PREFIX + "failed-logins";
 
     /** Listener attribute */
-    private static final String ATTRIBUTE_LISTENER =                ATTRIBUTE_PREFIX + "listener";
+    private static final String ATTRIBUTE_LISTENER = ATTRIBUTE_PREFIX + "listener";
 
     /** Max idle time attribute */
-    private static final String ATTRIBUTE_MAX_IDLE_TIME =           ATTRIBUTE_PREFIX + "max-idle-time";
+    private static final String ATTRIBUTE_MAX_IDLE_TIME = ATTRIBUTE_PREFIX + "max-idle-time";
 
     /** Last access time attribute */
-    private static final String ATTRIBUTE_LAST_ACCESS_TIME =        ATTRIBUTE_PREFIX + "last-access-time";
+    private static final String ATTRIBUTE_LAST_ACCESS_TIME = ATTRIBUTE_PREFIX + "last-access-time";
 
     /** Cached remote address attribute */
-    private static final String ATTRIBUTE_CACHED_REMOTE_ADDRESS =   ATTRIBUTE_PREFIX + "cached-remote-address";
+    private static final String ATTRIBUTE_CACHED_REMOTE_ADDRESS = ATTRIBUTE_PREFIX + "cached-remote-address";
 
     /** The encapsulated IoSession instance */
     private final IoSession wrappedSession;
@@ -124,15 +124,19 @@ public class FtpIoSession implements IoSession {
     /**
      * Public constructor
      *
-     * @param wrappedSession The wrapped IoSession
-     * @param context The server cobtext
+     * @param wrappedSession
+     *         The wrapped IoSession
+     * @param context
+     *         The server cobtext
      */
     public FtpIoSession(IoSession wrappedSession, FtpServerContext context) {
         this.wrappedSession = wrappedSession;
+        this.wrappedSession.setAttribute(ATTRIBUTE_LAST_ACCESS_TIME, new LazyDateHolder());
         this.context = context;
     }
 
     /* Begin wrapped IoSession methods */
+
     /**
      * {@inheritDoc}
      */
@@ -570,6 +574,7 @@ public class FtpIoSession implements IoSession {
     }
 
     /* End wrapped IoSession methods */
+
     /**
      * Reset the session state. It will remove the 'rename-from' and 'file-offset'
      * attributes from the session
@@ -635,7 +640,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the listener attribute
      *
-     * @param listener The listener to set
+     * @param listener
+     *         The listener to set
      */
     public void setListener(Listener listener) {
         setAttribute(ATTRIBUTE_LISTENER, listener);
@@ -652,7 +658,8 @@ public class FtpIoSession implements IoSession {
 
     /**
      * Get the session's language
-     *-
+     * -
+     *
      * @return The session language
      */
     public String getLanguage() {
@@ -662,7 +669,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the session language
      *
-     * @param language The language to set
+     * @param language
+     *         The language to set
      */
     public void setLanguage(String language) {
         setAttribute(ATTRIBUTE_LANGUAGE, language);
@@ -672,7 +680,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the 'user' attribute
      *
-     * @param user The user for this session
+     * @param user
+     *         The user for this session
      */
     public void setUser(User user) {
         setAttribute(ATTRIBUTE_USER, user);
@@ -691,7 +700,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the user argument
      *
-     * @param userArgument The user argument to set
+     * @param userArgument
+     *         The user argument to set
      */
     public void setUserArgument(String userArgument) {
         setAttribute(ATTRIBUTE_USER_ARGUMENT, userArgument);
@@ -710,7 +720,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the max idle time for a session
      *
-     * @param maxIdleTime Maximum time a session can idle
+     * @param maxIdleTime
+     *         Maximum time a session can idle
      */
     public void setMaxIdleTime(int maxIdleTime) {
         setAttribute(ATTRIBUTE_MAX_IDLE_TIME, maxIdleTime);
@@ -749,7 +760,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the login attributes: 'login-time' and 'file-system'
      *
-     * @param fsview The file system view
+     * @param fsview
+     *         The file system view
      */
     public void setLogin(FileSystemView fsview) {
         setAttribute(ATTRIBUTE_LOGIN_TIME, new Date());
@@ -781,7 +793,7 @@ public class FtpIoSession implements IoSession {
             LoggerFactory.getLogger(this.getClass()).debug("Statistics login decreased due to user logout");
         } else {
             LoggerFactory.getLogger(
-                this.getClass()).warn("Statistics not available in session, can not decrease login  count");
+                    this.getClass()).warn("Statistics not available in session, can not decrease login  count");
         }
     }
 
@@ -797,7 +809,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the 'file-offset' attribute value.
      *
-     * @param fileOffset The 'file-offset' attribute value
+     * @param fileOffset
+     *         The 'file-offset' attribute value
      */
     public void setFileOffset(long fileOffset) {
         setAttribute(ATTRIBUTE_FILE_OFFSET, fileOffset);
@@ -816,7 +829,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the 'rename-from' attribute
      *
-     * @param renFr The 'rename-from' attribute value
+     * @param renFr
+     *         The 'rename-from' attribute value
      */
     public void setRenameFrom(FtpFile renFr) {
         setAttribute(ATTRIBUTE_RENAME_FROM, renFr);
@@ -835,7 +849,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the transfert structure
      *
-     * @param structure The structure (only FILE is currently supported)
+     * @param structure
+     *         The structure (only FILE is currently supported)
      */
     public void setStructure(Structure structure) {
         setAttribute(ATTRIBUTE_STRUCTURE, structure);
@@ -853,7 +868,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Set the data type
      *
-     * @param dataType The data type to use (ASCII or BINARY)
+     * @param dataType
+     *         The data type to use (ASCII or BINARY)
      */
     public void setDataType(DataType dataType) {
         setAttribute(ATTRIBUTE_DATA_TYPE, dataType);
@@ -890,7 +906,7 @@ public class FtpIoSession implements IoSession {
      * @return The last access time
      */
     public Date getLastAccessTime() {
-        return new Date((Long) getAttribute(ATTRIBUTE_LAST_ACCESS_TIME));
+        return ((LazyDateHolder) getAttribute(ATTRIBUTE_LAST_ACCESS_TIME)).getDate();
     }
 
     /**
@@ -924,7 +940,7 @@ public class FtpIoSession implements IoSession {
      * Update the last-access-time session attribute with the current date
      */
     public void updateLastAccessTime() {
-        setAttribute(ATTRIBUTE_LAST_ACCESS_TIME, System.currentTimeMillis());
+        ((LazyDateHolder) getAttribute(ATTRIBUTE_LAST_ACCESS_TIME)).update();
     }
 
     /**
@@ -975,7 +991,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Increase the number of bytes written on the data connection
      *
-     * @param increment The number of bytes written
+     * @param increment
+     *         The number of bytes written
      */
     public void increaseWrittenDataBytes(int increment) {
         if (wrappedSession instanceof AbstractIoSession) {
@@ -988,7 +1005,8 @@ public class FtpIoSession implements IoSession {
     /**
      * Increase the number of bytes read on the data connection
      *
-     * @param increment The number of bytes written
+     * @param increment
+     *         The number of bytes written
      */
     public void increaseReadDataBytes(int increment) {
         if (wrappedSession instanceof AbstractIoSession) {

--- a/core/src/main/java/org/apache/ftpserver/util/LazyDateHolder.java
+++ b/core/src/main/java/org/apache/ftpserver/util/LazyDateHolder.java
@@ -1,0 +1,89 @@
+package org.apache.ftpserver.util;
+
+import java.util.Date;
+
+/**
+ * A thread-safe holder for a timestamp that lazily creates a corresponding {@link Date} object.
+ * <p>
+ * This class is designed to optimize scenarios where the timestamp is frequently updated
+ * (such as during file transfers), but the {@code Date} object is rarely accessed.
+ * A new {@code Date} instance is created only when the timestamp value changes,
+ * minimizing unnecessary object allocations and reducing garbage collection pressure.
+ * </p>
+ *
+ * <p>
+ * All methods that access or modify the cached {@code Date} are properly synchronized
+ * to ensure atomic visibility of the timestamp and associated {@code Date}.
+ * </p>
+ */
+public final class LazyDateHolder {
+
+    private long timeMillis;
+
+    private Date cachedDate;
+
+    /**
+     * Creates a new {@code LazyDateHolder} initialized with the specified time in milliseconds.
+     *
+     * @param initialTimeMillis
+     *         the initial timestamp value in milliseconds since the epoch
+     */
+    public LazyDateHolder(long initialTimeMillis) {
+        this.timeMillis = initialTimeMillis;
+        this.cachedDate = new Date(initialTimeMillis);
+    }
+
+    /**
+     * Creates a new {@code LazyDateHolder} initialized with the current system time.
+     */
+    public LazyDateHolder() {
+        this(System.currentTimeMillis());
+    }
+
+    /**
+     * Updates the timestamp to the specified value in milliseconds since the epoch.
+     * <p>
+     * If the new timestamp differs from the current one, the cached {@code Date} object is refreshed.
+     * </p>
+     *
+     * @param newTimeMillis
+     *         the new timestamp value in milliseconds
+     */
+    public synchronized void update(long newTimeMillis) {
+        if (this.timeMillis != newTimeMillis) {
+            this.timeMillis = newTimeMillis;
+            this.cachedDate = new Date(newTimeMillis);
+        }
+    }
+
+    /**
+     * Updates the timestamp to the current system time.
+     * <p>
+     * If the new timestamp differs from the current one, the cached {@code Date} object is refreshed.
+     * </p>
+     */
+    public void update() {
+        update(System.currentTimeMillis());
+    }
+
+    /**
+     * Returns the cached {@code Date} instance representing the current timestamp.
+     * <p>
+     * This {@code Date} object is updated lazily and only changes when the timestamp value changes.
+     * </p>
+     *
+     * @return the cached {@code Date} corresponding to the last update time
+     */
+    public synchronized Date getDate() {
+        return cachedDate;
+    }
+
+    /**
+     * Returns the current timestamp value in milliseconds since the epoch.
+     *
+     * @return the current timestamp in milliseconds
+     */
+    public long getTimeMillis() {
+        return timeMillis;
+    }
+}

--- a/core/src/main/java/org/apache/ftpserver/util/LazyDateHolder.java
+++ b/core/src/main/java/org/apache/ftpserver/util/LazyDateHolder.java
@@ -30,7 +30,7 @@ public final class LazyDateHolder {
      */
     public LazyDateHolder(long initialTimeMillis) {
         this.timeMillis = initialTimeMillis;
-        this.cachedDate = new Date(initialTimeMillis);
+        this.cachedDate = null;
     }
 
     /**
@@ -52,7 +52,7 @@ public final class LazyDateHolder {
     public synchronized void update(long newTimeMillis) {
         if (this.timeMillis != newTimeMillis) {
             this.timeMillis = newTimeMillis;
-            this.cachedDate = new Date(newTimeMillis);
+            this.cachedDate = null;
         }
     }
 
@@ -75,7 +75,16 @@ public final class LazyDateHolder {
      * @return the cached {@code Date} corresponding to the last update time
      */
     public synchronized Date getDate() {
+        if(cachedDate == null)
+        {
+            cachedDate = new Date(timeMillis);
+        }
         return cachedDate;
+    }
+
+    synchronized boolean isDateNull()
+    {
+        return cachedDate == null;
     }
 
     /**

--- a/core/src/test/java/org/apache/ftpserver/util/LazyDateHolderTest.java
+++ b/core/src/test/java/org/apache/ftpserver/util/LazyDateHolderTest.java
@@ -1,0 +1,108 @@
+package org.apache.ftpserver.util;
+
+import junit.framework.TestCase;
+
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Unit tests for {@link LazyDateHolder}.
+ */
+public class LazyDateHolderTest extends TestCase {
+
+    public void testInitialTimeFromConstructor() {
+        long now = System.currentTimeMillis();
+        LazyDateHolder holder = new LazyDateHolder(now);
+        assertEquals("Initial timeMillis should match provided value", now, holder.getTimeMillis());
+        assertEquals("Initial Date should match provided value", now, holder.getDate().getTime());
+    }
+
+    public void testInitialTimeFromNoArgConstructor() {
+        LazyDateHolder holder = new LazyDateHolder();
+        long now = System.currentTimeMillis();
+        long diff = Math.abs(holder.getTimeMillis() - now);
+        assertTrue("Initial timeMillis should be close to current time", diff < 1000);
+    }
+
+    public void testUpdateWithSameTimeDoesNotChangeDate() {
+        long now = System.currentTimeMillis();
+        LazyDateHolder holder = new LazyDateHolder(now);
+        Date firstDate = holder.getDate();
+
+        holder.update(now); // update with same millis
+        Date secondDate = holder.getDate();
+
+        assertSame("Date instance should not change if timeMillis is the same", firstDate, secondDate);
+    }
+
+    public void testUpdateWithDifferentTimeChangesDate() {
+        long now = System.currentTimeMillis();
+        LazyDateHolder holder = new LazyDateHolder(now);
+        Date firstDate = holder.getDate();
+
+        holder.update(now + 1000); // advance by 1 second
+        Date secondDate = holder.getDate();
+
+        assertNotSame("Date instance should change when timeMillis changes", firstDate, secondDate);
+        assertEquals("Date should reflect updated timeMillis", now + 1000, secondDate.getTime());
+    }
+
+    public void testUpdateWithoutArgumentUsesCurrentTime() throws InterruptedException {
+        LazyDateHolder holder = new LazyDateHolder();
+        Date firstDate = holder.getDate();
+        Thread.sleep(5); // ensure time passes
+        holder.update(); // auto update
+        Date secondDate = holder.getDate();
+
+        assertTrue("Date after auto update should be newer", secondDate.getTime() > firstDate.getTime());
+    }
+
+    public void testConcurrentUpdateAndGet() throws InterruptedException {
+        final LazyDateHolder holder = new LazyDateHolder();
+        final AtomicReference<Exception> failure = new AtomicReference<>(null);
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        Runnable updater = new Runnable() {
+            public void run() {
+                try {
+                    for (int i = 0; i < 1000; i++) {
+                        holder.update();
+                        Thread.sleep(1);
+                    }
+                } catch (Exception e) {
+                    failure.set(e);
+                } finally {
+                    latch.countDown();
+                }
+            }
+        };
+
+        Runnable getter = new Runnable() {
+            public void run() {
+                try {
+                    for (int i = 0; i < 1000; i++) {
+                        Date date = holder.getDate();
+                        assertNotNull("Date should never be null during concurrent access", date);
+                        Thread.sleep(1);
+                    }
+                } catch (Exception e) {
+                    failure.set(e);
+                } finally {
+                    latch.countDown();
+                }
+            }
+        };
+
+        Thread updateThread = new Thread(updater);
+        Thread getThread = new Thread(getter);
+        updateThread.start();
+        getThread.start();
+
+        latch.await(); // wait for both threads to finish
+
+        if (failure.get() != null) {
+            fail("Exception occurred during concurrent test: " + failure.get().getMessage());
+        }
+    }
+}

--- a/core/src/test/java/org/apache/ftpserver/util/LazyDateHolderTest.java
+++ b/core/src/test/java/org/apache/ftpserver/util/LazyDateHolderTest.java
@@ -58,6 +58,28 @@ public class LazyDateHolderTest extends TestCase {
         assertTrue("Date after auto update should be newer", secondDate.getTime() > firstDate.getTime());
     }
 
+    public void testNullDateWithUpdate() throws InterruptedException {
+        LazyDateHolder holder = new LazyDateHolder();
+        assertTrue("Initially should be null",holder.isDateNull());
+
+        Thread.sleep(5); // ensure time passes
+        holder.update(); // auto update
+        Date secondDate = holder.getDate();
+        assertFalse("Should not be null as date retrieved",holder.isDateNull());
+        Thread.sleep(5); // ensure time passes
+        holder.update(); // auto update
+        assertTrue("Should be not null due to update",holder.isDateNull());
+
+        long now = System.currentTimeMillis();
+        holder.update(now);
+        assertTrue("Should be not null due to update",holder.isDateNull());
+
+        Date customDate = holder.getDate();
+        holder.update(now);  // same value
+        assertFalse("Should be not null as the update was the same",holder.isDateNull());
+        assertEquals("Should be not null as the update was the same",customDate,holder.getDate());
+    }
+
     public void testConcurrentUpdateAndGet() throws InterruptedException {
         final LazyDateHolder holder = new LazyDateHolder();
         final AtomicReference<Exception> failure = new AtomicReference<>(null);


### PR DESCRIPTION
This change optimizes FtpIoSession by internally storing lastAccessTime as a long instead of a Date.
During file transfers, lastAccessTime is updated every 4 KB, leading to frequent Date object allocations.
In contrast, reads of lastAccessTime occur infrequently — typically only after FTP command execution, during idle timeout checks, or via rare administrative commands.

By using a long and creating a Date only when accessed, we eliminate unnecessary object churn, significantly reducing GC overhead and memory fragmentation in high-concurrency environments.
This improves throughput and scalability without affecting API compatibility.