### PR TITLE
Update FtpLoggingFilter

### DIFF
--- a/core/src/main/java/org/apache/ftpserver/listener/nio/FtpLoggingFilter.java
+++ b/core/src/main/java/org/apache/ftpserver/listener/nio/FtpLoggingFilter.java
@@ -72,7 +72,7 @@ public class FtpLoggingFilter extends LoggingFilter {
     public void messageReceived(NextFilter nextFilter, IoSession session, Object message) throws Exception {
         String request = (String) message;
 
-        if (maskPassword && (request.trim().toUpperCase().startsWith("PASS "))) {
+        if ((request.trim().toUpperCase().startsWith("PASS ")) && maskPassword) {
             logger.info("RECEIVED: PASS *****");
         } else {
             logger.info("RECEIVED: {}", request);


### PR DESCRIPTION
Hey there! :)
I see this place is already refactored in comparison with 'master' branch and my changes are quite minor, but maybe you will find them useful. I propose to realign if-conditions from `maskPassword && (request.trim().toUpperCase().startsWith("PASS "))` to `(request.trim().toUpperCase().startsWith("PASS ")) && maskPassword` due to usual use cases:
- maskPassword is mostly set to true
- request mostly _does not_ start with "PASS " during regular FTP-sessions

It will help us to hit the else-branch earlier.